### PR TITLE
Add thresholded z-bar blending and FID diagnostics

### DIFF
--- a/main_per_digit.py
+++ b/main_per_digit.py
@@ -374,6 +374,7 @@ if __name__ == "__main__":
     eval_cfg['fuse_lambda'] = 0.65
     eval_cfg['delta_fuse'] = (0.9 - eval_cfg['fuse_lambda']) / eval_cfg['n_iters']
     eval_cfg['sigma'] = 1
+    eval_cfg['d_thresh'] = 0.5
     eval_cfg['noise_factor'] = NOISE_INTER
     eval_cfg['elastic_alpha'] = 34.0
     eval_cfg['elastic_sigma'] = EL_INTER


### PR DESCRIPTION
## Summary
- compute mean difference and covariance eigenvalues when evaluating FID
- save example real/generated images alongside per-digit FID stats
- gate z-bar fusion by a distance threshold during reconstruction

## Testing
- `python -m py_compile utils.py mnist_fid_implementation.py main_per_digit.py`

------
https://chatgpt.com/codex/tasks/task_e_68936538811c8327b8d6f4a9e9b786e8